### PR TITLE
show table under toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,8 +464,26 @@
 				// Add content row, check if it has attributes (and enable toggler if so)
 				const newContentRow = contentRow.cloneNode(true);	// Deep clone copy
 				if (needsJSONContentRow(event)) {
-					// Add the JSON representation of the attributes to the content row
-					newContentRow.lastElementChild.textContent = JSON.stringify(event.a, null, "\t");
+					// Add a Table representation of the attributes to the content row
+					const inspector = document.createElement("table");
+					for (const key in event.a) {						
+						let inspectRow = document.createElement("tr");
+						// key
+						let inspectCellKey = document.createElement("td");
+						inspectCellKey.textContent = key;
+						inspectRow.appendChild(inspectCellKey);
+						// val 
+						let val = event.a[key];
+						let inspectCellVal = document.createElement("td");
+						if (typeof val === 'object') {
+							inspectCellVal.textContent = JSON.stringify(val);
+						} else {
+							inspectCellVal.textContent = val;
+						}
+						inspectRow.appendChild(inspectCellVal);
+						inspector.appendChild(inspectRow);						
+					}
+					newContentRow.appendChild(inspector);															
 				} else {
 					// Remove toggler and the visible triangle of toggler
 					cells[0].classList.remove("toggler");


### PR DESCRIPTION
currently, the JSON string of the whole attrs are show under toggle.
This results in escaping the keys and values of a JSON object which makes it hard to read and copy.

This PR will show a HTML table with keys in column 0 and values in column 1, as plain as possible.